### PR TITLE
Ir es change

### DIFF
--- a/code-documentation/swangraph.md
+++ b/code-documentation/swangraph.md
@@ -172,6 +172,8 @@ Returns:
                 at least one novel exon skipping event
         es_transcripts (list of str): A list of transcript ids from the 
                 SwanGraph with at least one novel exon skipping event
+        es_edges (list of tuples): A list of intronic edges in the 
+            SwanGraph that skip at least one exonic edge
 ```
 
 ### find\_ir\_genes
@@ -189,6 +191,8 @@ Returns:
                 at least one novel intron retention event
         ir_transcripts (list of str): A list of transcript ids from the 
                 SwanGraph with at least one novel intron retention event
+        ir_edges (list of tuples): A list of exonic edges in the
+                SwanGraph that retain at least one intronic edge
 ```
 
 ### find\_isoform\_switching\_genes

--- a/swan_vis/swangraph.py
+++ b/swan_vis/swangraph.py
@@ -991,6 +991,8 @@ class SwanGraph(Graph):
 					at least one novel intron retention event
 				ir_transcripts (list of str): A list of transcript ids from the 
 					SwanGraph with at least one novel intron retention event
+				ir_edges (list of tuples): A list of exonic edges in the
+					SwanGraph that retain at least one intronic edge
 		"""
 
 		# get only novel edges
@@ -1008,19 +1010,16 @@ class SwanGraph(Graph):
 		
 		# for each edge, see if the subgraph between the edge vertices 
 		# contains an exonic edge  
+		ir_edges = []
 		ir_genes = []
 		ir_transcripts = []
 		for i, eid in enumerate(edge_ids):
 			sub_nodes = [i for i in range(eid[0]+1,eid[1])]
 			sub_G = self.G.subgraph(sub_nodes)
 			sub_edges = list(sub_G.edges())
-			try:
-				sub_edges = self.edge_df.loc[sub_edges]
-			except:
-				for blop in sub_edges:
-					if blop not in self.edge_df.edge_id.tolist():
-						print(blop)
-						continue
+			sub_edges = self.edge_df.loc[sub_edges]
+			# find edges that are intronic; if there are none, this is not
+			# an intron-retaining edge
 			sub_edges = sub_edges.loc[sub_edges.edge_type == 'intron']
 
 			if len(sub_edges.index) > 0:
@@ -1047,17 +1046,20 @@ class SwanGraph(Graph):
 						for cand_eid in sub_edges.index:
 							temp_df = cand_g_df[[cand_eid in vertex_to_edge_path(x) \
 									for x in cand_g_df.path.values.tolist()]]
-							tids = temp_df.tid.tolist()
+							tids = cand_t_df.tid.tolist()
 							if len(temp_df.index) > 0:
+								ir_edges.append(eid)
 								ir_genes.append(gid)
 								ir_transcripts.extend(tids)
 
-		print('Found {} novel ir events from {} genes.'.format(len(ir_genes), 
-			len(list(set(ir_genes)))))
 		ir_genes = list(set(ir_genes))
 		ir_transcripts = list(set(ir_transcripts))
+		ir_edges = list(set(ir_edges))
 
-		return ir_genes, ir_transcripts
+		print('Found {} novel ir events from {} transcripts.'.format(len(ir_genes), 
+			len(ir_transcripts)))
+
+		return ir_genes, ir_transcripts, ir_edges
 
 	def find_es_genes(self):
 		"""
@@ -1070,6 +1072,8 @@ class SwanGraph(Graph):
 					at least one novel exon skipping event
 				es_transcripts (list of str): A list of transcript ids from the 
 					SwanGraph with at least one novel exon skipping event
+				es_edges (list of tuples): A list of intronic edges in the 
+					SwanGraph that skip at least one exonic edge
 		"""
 
 		# get only novel edges
@@ -1087,18 +1091,23 @@ class SwanGraph(Graph):
 
 		# for each edge, see if the subgraph between the edge vertices 
 		# contains an exonic edge
+		es_edges = []
 		es_genes = []
 		es_transcripts = []
 		for eid in edge_ids:
+			# subgraph consisting of all nodes between the candidate
+			# exon-skipping edge coords in order and its edges
 			sub_nodes = [i for i in range(eid[0]+1,eid[1])]
 			sub_G = self.G.subgraph(sub_nodes)
 			sub_edges = list(sub_G.edges())
 			sub_edges = self.edge_df.loc[sub_edges]
+			# find edges that are exonic; if there are none, this is not 
+			# an exon-skipping edge
 			sub_edges = sub_edges.loc[sub_edges.edge_type == 'exon']
 
 			if len(sub_edges.index) > 0:
 
-				# transcripts that contain the exon-skipping edge
+				# transcripts that contain the candidate exon-skipping edge
 				skip_t_df = nt_df[[eid in vertex_to_edge_path(x) \
 					for x in nt_df.path.values.tolist()]]
 
@@ -1109,7 +1118,7 @@ class SwanGraph(Graph):
 				# does at least one of the skipped exons belong
 				# to the same gene as the skipping edge?
 				else:
-					# genes that contain the exon-skipping edge
+					# genes that contain the candidate exon-skipping edge
 					skip_genes = skip_t_df.gid.values.tolist()
 					skip_g_df = self.t_df.loc[self.t_df.gid.isin(skip_genes)]
 
@@ -1118,19 +1127,24 @@ class SwanGraph(Graph):
 					for gid in skip_genes:
 						if gid in es_genes: continue
 						for skip_eid in sub_edges.index:
+							# transcripts with the exons that are skipped
 							temp_df = skip_g_df[[skip_eid in vertex_to_edge_path(x) \
 									for x in skip_g_df.path.values.tolist()]]
-							tids = temp_df.tid.tolist()
+							tids = skip_t_df.tid.tolist()
 							if len(temp_df.index) > 0:
+								es_edges.append(eid)
 								es_genes.append(gid)
 								es_transcripts.extend(tids)
 
-		print('Found {} novel es events from {} genes.'.format(len(es_genes),
-			len(list(set(es_genes)))))
 		es_genes = list(set(es_genes))
 		es_transcripts = list(set(es_transcripts))
+		es_edges = list(set(es_edges))
 
-		return es_genes, es_transcripts
+		print('Found {} novel es events in {} transcripts.'.format(len(es_edges),
+			len(es_transcripts)))
+
+
+		return es_genes, es_transcripts, es_edges
 
 	def de_gene_test(self, dataset_groups):
 		""" 

--- a/tutorials/Analysis tools.ipynb
+++ b/tutorials/Analysis tools.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -1229,7 +1229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -1237,13 +1237,13 @@
      "output_type": "stream",
      "text": [
       "Analyzing 893 intronic edges for ES\n",
-      "Found 1021 novel es events from 285 genes.\n",
-      "['ENSG00000130706.12', 'ENSG00000111237.18', 'ENSG00000101363.12', 'ENSG00000163069.12', 'ENSG00000132677.12']\n"
+      "Found 285 novel es events in 298 transcripts.\n",
+      "['ENSG00000089022.13', 'ENSG00000204525.16', 'ENSG00000138069.17', 'ENSG00000147955.16', 'ENSG00000183011.13']\n"
      ]
     }
    ],
    "source": [
-    "es_genes = sg.find_es_genes()\n",
+    "es_genes, es_transcripts, es_edges = sg.find_es_genes()\n",
     "print(es_genes[:5])"
    ]
   },
@@ -1263,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -1271,13 +1271,13 @@
      "output_type": "stream",
      "text": [
       "Analyzing 2185 exonic edges for IR\n",
-      "Found 73 novel ir events from 47 genes.\n",
-      "['ENSG00000213719.8', 'ENSG00000135480.15', 'ENSG00000196421.8', 'ENSG00000141505.11', 'ENSG00000030582.17']\n"
+      "Found 47 novel ir events from 49 transcripts.\n",
+      "['ENSG00000272779.1', 'ENSG00000179218.13', 'ENSG00000067167.7', 'ENSG00000104904.12', 'ENSG00000161203.13']\n"
      ]
     }
    ],
    "source": [
-    "ir_genes = sg.find_ir_genes()\n",
+    "ir_genes, ir_transcripts, ir_edges = sg.find_ir_genes()\n",
     "print(ir_genes[:5])"
    ]
   },

--- a/tutorials/analysis_tools.md
+++ b/tutorials/analysis_tools.md
@@ -186,14 +186,14 @@ Swan can detect novel \(unannotated\) exon skipping and intron retention events.
 To obtain a list of genes containing novel exon skipping events, run the following code:
 
 ```python
-es_genes = sg.find_es_genes()
+es_genes, es_transcripts, es_edges = sg.find_es_genes()
 print(es_genes[:5])
 ```
 
 ```text
 Analyzing 893 intronic edges for ES
-Found 1021 novel es events from 285 genes.
-['ENSG00000130706.12', 'ENSG00000111237.18', 'ENSG00000101363.12', 'ENSG00000163069.12', 'ENSG00000132677.12']
+Found 285 novel es events in 298 transcripts.
+['ENSG00000089022.13', 'ENSG00000204525.16', 'ENSG00000138069.17', 'ENSG00000147955.16', 'ENSG00000183011.13']
 ```
 
 As usual, we can feed `es_genes` into `gen_report()` or individual gene ids from `es_genes` into `plot_graph()` to generate gene reports or gene summary graphs respectively.
@@ -201,14 +201,14 @@ As usual, we can feed `es_genes` into `gen_report()` or individual gene ids from
 To obtain a list of genes containing novel intron retention events, run the following code:
 
 ```python
-ir_genes = sg.find_ir_genes()
+ir_genes, ir_transcripts, ir_edges = sg.find_ir_genes()
 print(ir_genes[:5])
 ```
 
 ```text
 Analyzing 2185 exonic edges for IR
-Found 73 novel ir events from 47 genes.
-['ENSG00000213719.8', 'ENSG00000135480.15', 'ENSG00000196421.8', 'ENSG00000141505.11', 'ENSG00000030582.17']
+Found 47 novel ir events from 49 transcripts.
+['ENSG00000272779.1', 'ENSG00000179218.13', 'ENSG00000067167.7', 'ENSG00000104904.12', 'ENSG00000161203.13']
 ```
 
 As usual, we can feed `ir_genes` into `gen_report()` or individual gene ids from `ir_genes` into `plot_graph()` to generate gene reports or gene summary graphs respectively.


### PR DESCRIPTION
Update to how intron retention and exon skipping detection work

- each exon-skipping or intron-retaining edge is counted as ONE event regardless of how many exons/introns it skips

- now the function returns the edge id from the SwanGraph of each edge found to be exon-skipping or intron-retaining

- updates the documentation to reflect these changes